### PR TITLE
Accept license, and improve logic in `check`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:xenial
 RUN apt-get update && apt-get install -y curl wget jq
 
 RUN curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | bash
+RUN hab license accept
 
 COPY check /opt/resource/check
 COPY in    /opt/resource/in

--- a/check
+++ b/check
@@ -47,7 +47,7 @@ range_start=$(curl "${base_uri}/channels/${origin}/${channel}/pkgs/${name}"  2>/
 per_page=$(( $range_end - $range_start + 1 ))
 
 if [[ release_count > $per_page ]]; then
-  release_range=(( $release_count / $per_page * $per_page ))
+  release_range=$(( $release_count / $per_page * $per_page ))
   curl "${base_uri}/channels/${origin}/${channel}/pkgs/${name}?range=${release_range}"  2>/dev/null | jq "[.data | to_entries[] | {\"ref\": (.value.version + \"/\" + .value.release )} ]" >&3
 else
   curl "${base_uri}/channels/${origin}/${channel}/pkgs/${name}"  2>/dev/null | jq "[.data | to_entries[] | {\"ref\": (.value.version + \"/\" + .value.release )} ]" >&3

--- a/check
+++ b/check
@@ -41,4 +41,14 @@ else
     platform=$src_platform
 fi
 
-curl "${base_uri}/channels/${origin}/${channel}/pkgs/${name}"  2>/dev/null | jq "[.data | to_entries[] | {\"ref\": (.value.version + \"/\" + .value.release )} ]" >&3
+release_count=$(curl "${base_uri}/channels/${origin}/${channel}/pkgs/${name}"  2>/dev/null | jq .total_count)
+range_end=$(curl "${base_uri}/channels/${origin}/${channel}/pkgs/${name}"  2>/dev/null | jq .range_end)
+range_start=$(curl "${base_uri}/channels/${origin}/${channel}/pkgs/${name}"  2>/dev/null | jq .range_start)
+per_page=$(( $range_end - $range_start + 1 ))
+
+if [[ release_count > $per_page ]]; then
+  release_range=(( $release_count / $per_page * $per_page ))
+  curl "${base_uri}/channels/${origin}/${channel}/pkgs/${name}?range=${release_range}"  2>/dev/null | jq "[.data | to_entries[] | {\"ref\": (.value.version + \"/\" + .value.release )} ]" >&3
+else
+  curl "${base_uri}/channels/${origin}/${channel}/pkgs/${name}"  2>/dev/null | jq "[.data | to_entries[] | {\"ref\": (.value.version + \"/\" + .value.release )} ]" >&3
+fi


### PR DESCRIPTION
Resolution for #1.

Existing logic works just fine until enough releases are in bldr to trigger pagination, after which point the `check` script won't capture any new releases.

Updated with a conditional such that if the number of releases exceeds the per-page settings of the query, it'll adjust to grab only the latest.

Of note, I've also added a `hab license accept` to the dockerfile, since it'll hit licensing errors with latest otherwise. If there's a better way for me to handle the license acceptence lmk. Wasn't sure what SOP looks like in this edge case. 
